### PR TITLE
Auto-deactivate the plugin when PHP < 5.3.

### DIFF
--- a/Cmb2GridPlugin.php
+++ b/Cmb2GridPlugin.php
@@ -1,133 +1,42 @@
 <?php
+/**
+ * Plugin Name: CMB2 Grid
+ * Plugin URI:  https://github.com/origgami/CMB2-grid
+ * Description: A grid system for Wordpress CMB2 library that allows columns creation
+ * Version:     1.0.0
+ * Author:      Origgami
+ * Author URI:  http://origgami.com.br
+ * Depends:     CMB2
+ * License:     GPLv2
+ * Text Domain: cmb2-grid
 
-namespace Cmb2Grid;
-
-if (!defined('CMB2GRID_DIR')) {
-	define('CMB2GRID_DIR', trailingslashit(dirname(__FILE__)));
-}
-
-/*
-  Plugin Name: CMB2 Grid
-  Plugin URI: https://github.com/origgami/CMB2-grid
-  Description: A grid system for Wordpress CMB2 library that allows columns creation
-  Version: 1.0.0
-  Author: Origgami
-  Author URI: http://origgami.com.br
-  Depends: CMB2
-  License: GPLv2
  */
-
-if (!class_exists('\Cmb2Grid\Cmb2GridPlugin')) {
-
-	require_once dirname(__FILE__) . '/DesignPatterns/Singleton.php';
-
-	class Cmb2GridPlugin extends DesignPatterns\Singleton {
-
-		const VERSION = '1.0';
-
-		protected function __construct() {
-			parent::__construct();
-			$this->loadFiles();
-			add_action('admin_head', array($this, 'wpHead'));
-			add_action('admin_enqueue_scripts', array($this, 'admin_enqueue_scripts'));
-			//$this->test();
-		}
-
-		private function test() {
-			require dirname(__FILE__) . '/Test/Test.php';
-			new Test\Test();
-		}
-
-		private function loadFiles() {
-			if (is_admin()) {
-				require dirname(__FILE__) . '/Grid/Cmb2Grid.php';
-				require dirname(__FILE__) . '/Grid/Column.php';
-				require dirname(__FILE__) . '/Grid/Row.php';
-
-				require dirname(__FILE__) . '/Grid/Group/Cmb2GroupGrid.php';
-				require dirname(__FILE__) . '/Grid/Group/GroupRow.php';
-				require dirname(__FILE__) . '/Grid/Group/GroupColumn.php';
+ 
 
 
-				require dirname(__FILE__) . '/Cmb2/Utils.php';
+/**
+ * Show admin notice & de-activate itself if PHP < 5.3 is detected.
+ */
+if ( version_compare( PHP_VERSION, '5.3', '<' ) ) {
+	add_action( 'admin_init', 'cmb2_grid_deactivate' );
+	
+	if ( ! function_exists( 'cmb2_grid_deactivate' ) ) {
+		/**
+		 * Check for parent plugin.
+		 */
+		function cmb2_grid_deactivate() {
+			if ( is_admin() && current_user_can( 'activate_plugins' ) && is_plugin_active( plugin_basename( __FILE__ ) ) ) {
+				add_action( 'admin_notices', create_function( null, 'echo \'<div class="error"><p>\', __( \'Activation failed: The CMB2 Grid plugin required PHP 5.3+. Please contact your webhost and ask them to upgrade the PHP version for your webhosting account.\', \'cmb2-grid\' ), \'</a></p></div>\';' ) );
+	
+				deactivate_plugins( plugin_basename( __FILE__ ) );
+				if ( isset( $_GET['activate'] ) ) {
+					unset( $_GET['activate'] );
+				}
 			}
-		}
-
-		public function admin_enqueue_scripts() {
-			$suffix = ( ( defined( 'SCRIPT_DEBUG' ) && SCRIPT_DEBUG ) ? '' : '.min' );
-			wp_enqueue_style( 'cmb2_grid_bootstrap_light', $this->url('assets/css/bootstrap' . $suffix . '.css'), null, self::VERSION );
-		}
-
-		public function wpHead() {
-			?>
-			<style>
-				.cmb2GridRow .cmb-row{border:none !important;padding:0 !important}
-				.cmb2GridRow .cmb-th label:after{border:none !important}
-				.cmb2GridRow .cmb-th{width:100% !important}
-				.cmb2GridRow .cmb-td{width:100% !important}
-				.cmb2GridRow input[type="text"], .cmb2GridRow textarea, .cmb2GridRow select{width:100%}
-
-				.cmb2GridRow .cmb-repeat-group-wrap{max-width:100% !important;}
-				.cmb2GridRow .cmb-group-title{margin:0 !important;}
-				.cmb2GridRow .cmb-repeat-group-wrap .cmb-row .cmbhandle, .cmb2GridRow .postbox-container .cmb-row .cmbhandle{right:0 !important}
-			</style>
-			<?php
-
-		}
-
-		// Based on CMB2_Utils url() method
-		public function url($path = '') {
-			if (isset($this->url)) {
-				return $this->url . $path;
-			}
-
-			if ('WIN' === strtoupper(substr(PHP_OS, 0, 3))) {
-				// Windows
-				$content_dir = str_replace('/', DIRECTORY_SEPARATOR, WP_CONTENT_DIR);
-				$content_url = str_replace($content_dir, WP_CONTENT_URL, CMB2GRID_DIR);
-				$cmb2_url	 = str_replace(DIRECTORY_SEPARATOR, '/', $content_url);
-			} else {
-				$cmb2_url = str_replace(
-					array(WP_CONTENT_DIR, WP_PLUGIN_DIR),
-					array(WP_CONTENT_URL, WP_PLUGIN_URL),
-					CMB2GRID_DIR
-				);
-			}
-
-			/**
-			 * Filter the CMB location url
-			 *
-			 * @param string $cmb2_url Currently registered url
-			 */
-			$this->url = trailingslashit(apply_filters('cmb2_meta_box_url', set_url_scheme($cmb2_url), CMB2_VERSION));
-
-			return $this->url . $path;
-		}
-
-	}
-
-}
-
-
-/* Instantiate the class on plugins_loaded. */
-// wp_installing() function was introduced in WP 4.4.
-if ( ( function_exists( 'wp_installing' ) && wp_installing() === false ) || ( ! function_exists( 'wp_installing' ) && ( ! defined( 'WP_INSTALLING' ) || WP_INSTALLING === false ) ) ) {
-	add_action( 'plugins_loaded', '\\' . __NAMESPACE__ . '\init' );
-}
-
-if ( ! function_exists( '\Cmb2Grid\init' ) ) {
-	/**
-	 * Initialize the class only if CMB2 is detected.
-	 *
-	 * @return void
-	 */
-	function init() {
-		if ( defined( 'CMB2_LOADED' ) ) {
-			if (!defined('CMB2GRID_DIR')) {
-				define('CMB2GRID_DIR', trailingslashit(dirname(__FILE__)));
-			}
-			Cmb2GridPlugin::getInstance();
 		}
 	}
 }
-
+/* Otherwise, load the plugin.  */
+else {
+	include_once __DIR__ . '/Cmb2GridPluginLoad.php';
+}

--- a/Cmb2GridPluginLoad.php
+++ b/Cmb2GridPluginLoad.php
@@ -1,0 +1,123 @@
+<?php
+
+namespace Cmb2Grid;
+
+if (!defined('CMB2GRID_DIR')) {
+	define('CMB2GRID_DIR', trailingslashit(dirname(__FILE__)));
+}
+
+
+if (!class_exists('\Cmb2Grid\Cmb2GridPlugin')) {
+
+	require_once dirname(__FILE__) . '/DesignPatterns/Singleton.php';
+
+	class Cmb2GridPlugin extends DesignPatterns\Singleton {
+
+		const VERSION = '1.0';
+
+		protected function __construct() {
+			parent::__construct();
+			$this->loadFiles();
+			add_action('admin_head', array($this, 'wpHead'));
+			add_action('admin_enqueue_scripts', array($this, 'admin_enqueue_scripts'));
+			//$this->test();
+		}
+
+		private function test() {
+			require dirname(__FILE__) . '/Test/Test.php';
+			new Test\Test();
+		}
+
+		private function loadFiles() {
+			if (is_admin()) {
+				require dirname(__FILE__) . '/Grid/Cmb2Grid.php';
+				require dirname(__FILE__) . '/Grid/Column.php';
+				require dirname(__FILE__) . '/Grid/Row.php';
+
+				require dirname(__FILE__) . '/Grid/Group/Cmb2GroupGrid.php';
+				require dirname(__FILE__) . '/Grid/Group/GroupRow.php';
+				require dirname(__FILE__) . '/Grid/Group/GroupColumn.php';
+
+
+				require dirname(__FILE__) . '/Cmb2/Utils.php';
+			}
+		}
+
+		public function admin_enqueue_scripts() {
+			$suffix = ( ( defined( 'SCRIPT_DEBUG' ) && SCRIPT_DEBUG ) ? '' : '.min' );
+			wp_enqueue_style( 'cmb2_grid_bootstrap_light', $this->url('assets/css/bootstrap' . $suffix . '.css'), null, self::VERSION );
+		}
+
+		public function wpHead() {
+			?>
+			<style>
+				.cmb2GridRow .cmb-row{border:none !important;padding:0 !important}
+				.cmb2GridRow .cmb-th label:after{border:none !important}
+				.cmb2GridRow .cmb-th{width:100% !important}
+				.cmb2GridRow .cmb-td{width:100% !important}
+				.cmb2GridRow input[type="text"], .cmb2GridRow textarea, .cmb2GridRow select{width:100%}
+
+				.cmb2GridRow .cmb-repeat-group-wrap{max-width:100% !important;}
+				.cmb2GridRow .cmb-group-title{margin:0 !important;}
+				.cmb2GridRow .cmb-repeat-group-wrap .cmb-row .cmbhandle, .cmb2GridRow .postbox-container .cmb-row .cmbhandle{right:0 !important}
+			</style>
+			<?php
+
+		}
+
+		// Based on CMB2_Utils url() method
+		public function url($path = '') {
+			if (isset($this->url)) {
+				return $this->url . $path;
+			}
+
+			if ('WIN' === strtoupper(substr(PHP_OS, 0, 3))) {
+				// Windows
+				$content_dir = str_replace('/', DIRECTORY_SEPARATOR, WP_CONTENT_DIR);
+				$content_url = str_replace($content_dir, WP_CONTENT_URL, CMB2GRID_DIR);
+				$cmb2_url	 = str_replace(DIRECTORY_SEPARATOR, '/', $content_url);
+			} else {
+				$cmb2_url = str_replace(
+					array(WP_CONTENT_DIR, WP_PLUGIN_DIR),
+					array(WP_CONTENT_URL, WP_PLUGIN_URL),
+					CMB2GRID_DIR
+				);
+			}
+
+			/**
+			 * Filter the CMB location url
+			 *
+			 * @param string $cmb2_url Currently registered url
+			 */
+			$this->url = trailingslashit(apply_filters('cmb2_meta_box_url', set_url_scheme($cmb2_url), CMB2_VERSION));
+
+			return $this->url . $path;
+		}
+
+	}
+
+}
+
+
+/* Instantiate the class on plugins_loaded. */
+// wp_installing() function was introduced in WP 4.4.
+if ( ( function_exists( 'wp_installing' ) && wp_installing() === false ) || ( ! function_exists( 'wp_installing' ) && ( ! defined( 'WP_INSTALLING' ) || WP_INSTALLING === false ) ) ) {
+	add_action( 'plugins_loaded', '\\' . __NAMESPACE__ . '\init' );
+}
+
+if ( ! function_exists( '\Cmb2Grid\init' ) ) {
+	/**
+	 * Initialize the class only if CMB2 is detected.
+	 *
+	 * @return void
+	 */
+	function init() {
+		if ( defined( 'CMB2_LOADED' ) ) {
+			if (!defined('CMB2GRID_DIR')) {
+				define('CMB2GRID_DIR', trailingslashit(dirname(__FILE__)));
+			}
+			Cmb2GridPlugin::getInstance();
+		}
+	}
+}
+


### PR DESCRIPTION
Namespaces were introduced in PHP 5.3. As this plugin uses them, the code will cause fatal errors on PHP 5.2.

The changes in this PR will prevent that.

The initial file has now essentially become a PHP5.2 compatible wrapper which will check the PHP version used and auto-deactivate the plugin when PHP5.2 is detected and notify the admin user of this (will generally happen straight after an activation attempt).

For higher PHP versions, the code will load the _real_ plugin.

Filename of the initial file is preserved and the _real_ plugin file renamed to prevent WP from failing to recognize/load an already activated version of this plugin after upgrade.

This does **not** solve #6, but it does prevent breaking websites which are still on 5.2.
