### PR TITLE
Add the plugin to `recently_active` plugins list if self-deactivating.

### DIFF
--- a/Cmb2GridPlugin.php
+++ b/Cmb2GridPlugin.php
@@ -23,10 +23,21 @@ if ( version_compare( PHP_VERSION, '5.3', '<' ) ) {
 		 * Check for parent plugin.
 		 */
 		function cmb2_grid_deactivate() {
-			if ( is_admin() && current_user_can( 'activate_plugins' ) && is_plugin_active( plugin_basename( __FILE__ ) ) ) {
+			$file = plugin_basename( __FILE__ );
+
+			if ( is_admin() && current_user_can( 'activate_plugins' ) && is_plugin_active( plugin_basename( $file ) ) ) {
 				add_action( 'admin_notices', create_function( null, 'echo \'<div class="error"><p>\', __( \'Activation failed: The CMB2 Grid plugin required PHP 5.3+. Please contact your webhost and ask them to upgrade the PHP version for your webhosting account.\', \'cmb2-grid\' ), \'</a></p></div>\';' ) );
 
-				deactivate_plugins( plugin_basename( __FILE__ ) );
+				deactivate_plugins( $file, false, is_network_admin() );
+
+				// Add to recently active plugins list.
+				if ( ! is_network_admin() ) {
+					update_option( 'recently_activated', array( $file => time() ) + (array) get_option( 'recently_activated' ) );
+				} else {
+					update_site_option( 'recently_activated', array( $file => time() ) + (array) get_site_option( 'recently_activated' ) );
+				}
+
+				// Prevent trying again on page reload.
 				if ( isset( $_GET['activate'] ) ) {
 					unset( $_GET['activate'] );
 				}


### PR DESCRIPTION
Compatible with multi-site/network (de-)activation.
