### PR TITLE
fix for custom directory

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "origgami/CMB2-grid",
+    "name": "origgami/cmb2-grid",
     "type": "wordpress-plugin",
     "require": {
         "composer/installers": "v1.1.0"


### PR DESCRIPTION
In composer the standard way for the names is lowercase in fact this package create some problems with module like custom directory installer.
To fix it it's only required to use a lowercase way. Composer.json support both not all the modules for composer because don't check that.
