### PR TITLE
Minor automated testing tweaks.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,8 +22,10 @@ matrix:
       env: SNIFF=1
     # aliased to a recent 5.6.x version
     - php: '5.6'
-    # aliased to a recent 7.x version
+    # aliased to a recent 7.0.x version
     - php: '7.0'
+    # aliased to a recent 7.1.x version
+    - php: '7.1'
     # aliased to a recent hhvm version
     - php: 'hhvm'
 
@@ -32,18 +34,16 @@ matrix:
 
 before_script:
   - export PHPCS_DIR=/tmp/phpcs
-  - export WPCS_DIR=/tmp/wpcs
+  - export SNIFFS_DIR=/tmp/sniffs
   # Install CodeSniffer for WordPress Coding Standards checks.
   - if [[ "$SNIFF" == "1" ]]; then git clone -b master --depth 1 https://github.com/squizlabs/PHP_CodeSniffer.git $PHPCS_DIR; fi
   # Install WordPress Coding Standards.
-  - if [[ "$SNIFF" == "1" ]]; then git clone -b master --depth 1 https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards.git $WPCS_DIR; fi
-  # Hop into CodeSniffer directory.
-  - if [[ "$SNIFF" == "1" ]]; then cd $PHPCS_DIR; fi
+  - if [[ "$SNIFF" == "1" ]]; then git clone -b master --depth 1 https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards.git $SNIFFS_DIR; fi
+  # Install PHP Compatibility sniffs.
+  - if [[ "$SNIFF" == "1" ]]; then git clone -b master --depth 1 https://github.com/wimg/PHPCompatibility.git $SNIFFS_DIR/PHPCompatibility; fi
   # Set install path for WordPress Coding Standards.
   # @link https://github.com/squizlabs/PHP_CodeSniffer/blob/4237c2fc98cc838730b76ee9cee316f99286a2a7/CodeSniffer.php#L1941
-  - if [[ "$SNIFF" == "1" ]]; then $PHPCS_DIR/scripts/phpcs --config-set installed_paths $WPCS_DIR; fi
-  # Hop back into project dir.
-  - if [[ "$SNIFF" == "1" ]]; then cd $TRAVIS_BUILD_DIR; fi
+  - if [[ "$SNIFF" == "1" ]]; then $PHPCS_DIR/scripts/phpcs --config-set installed_paths $SNIFFS_DIR; fi
   # After CodeSniffer install you should refresh your path.
   - if [[ "$SNIFF" == "1" ]]; then phpenv rehash; fi
 

--- a/Cmb2GridPlugin.php
+++ b/Cmb2GridPlugin.php
@@ -26,7 +26,7 @@ if ( version_compare( PHP_VERSION, '5.3', '<' ) ) {
 			$file = plugin_basename( __FILE__ );
 
 			if ( is_admin() && current_user_can( 'activate_plugins' ) && is_plugin_active( plugin_basename( $file ) ) ) {
-				add_action( 'admin_notices', create_function( null, 'echo \'<div class="error"><p>\', __( \'Activation failed: The CMB2 Grid plugin required PHP 5.3+. Please contact your webhost and ask them to upgrade the PHP version for your webhosting account.\', \'cmb2-grid\' ), \'</a></p></div>\';' ) );
+				add_action( 'admin_notices', create_function( null, 'echo \'<div class="error"><p>\', __( \'Activation failed: The CMB2 Grid plugin requires PHP 5.3+. Please contact your webhost and ask them to upgrade the PHP version for your webhosting account.\', \'cmb2-grid\' ), \'</a></p></div>\';' ) );
 
 				deactivate_plugins( $file, false, is_network_admin() );
 

--- a/Grid/Group/Cmb2GroupGrid.php
+++ b/Grid/Group/Cmb2GroupGrid.php
@@ -19,10 +19,6 @@ if ( ! class_exists( '\Cmb2Grid\Grid\Group\Cmb2GroupGrid' ) ) {
 
 		protected $parentFieldId;
 
-		public function __construct( $meta_box_config ) {
-			parent::__construct( $meta_box_config );
-		}
-
 		public function addRow() {
 			//parent::addRow();
 			$rows	 = $this->getRows();

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -2,6 +2,11 @@
 <ruleset name="CMB2 Grid">
 	<description>The code standard for CMB2 Grid is WordPress.</description>
 
+	<!-- PHP cross-version compatibility -->
+	<config name="testVersion" value="5.3-99.0"/>
+	<rule ref="PHPCompatibility"/>
+
+	<!-- Code style -->
 	<rule ref="WordPress">
 		<exclude name="Generic.Files.LowercasedFilename" />
 		<exclude name="WordPress.NamingConventions" />


### PR DESCRIPTION
- Add PHP 7.1 to the travis test matrix as it will be released soon.
- Add sniffing for cross-PHP version compatibility to the PHPCS ruleset with a preset `testVersion` so we receive the messages for the right PHP versions.
- Minor grammer fix.
- Minor code style fix (unnecessary overloading of parent method).
