### PR TITLE
load the library

### DIFF
--- a/Cmb2GridPluginLoad.php
+++ b/Cmb2GridPluginLoad.php
@@ -151,4 +151,5 @@ if ( ! function_exists( '\Cmb2Grid\init' ) ) {
 		}
 	}
 }
+add_action( 'cmb2_init',  '\Cmb2Grid\init' );
 


### PR DESCRIPTION
In that way if you are using composer to download the package but you want to avoid `autoload` you can point to the php file and the library will be loaded after cmb2