### PR TITLE
Don't make text_datetime_time fields full width.

### DIFF
--- a/Cmb2GridPluginLoad.php
+++ b/Cmb2GridPluginLoad.php
@@ -88,7 +88,7 @@ if ( ! class_exists( '\Cmb2Grid\Cmb2GridPlugin' ) ) {
 				.cmb2GridRow .cmb-th label:after{border:none !important}
 				.cmb2GridRow .cmb-th{width:100% !important}
 				.cmb2GridRow .cmb-td{width:100% !important}
-				.cmb2GridRow input[type="text"], .cmb2GridRow textarea, .cmb2GridRow select{width:100%}
+				.cmb2GridRow input[type="text"]:not( '.hasDatepicker' ), .cmb2GridRow textarea, .cmb2GridRow select{width:100%}
 
 				.cmb2GridRow .cmb-repeat-group-wrap{max-width:100% !important;}
 				.cmb2GridRow .cmb-group-title{margin:0 !important;}


### PR DESCRIPTION
I think these (awesome) fields are more useful without the full-width declaration.

So instead of 

```
DATE [                                                                                                                                    ]
TIME  [                                                                                                                                   ]
```

It looks like `DATE [      ] TIME [      ]`