### PR TITLE
Fix deprecation warning in php 8.2

### DIFF
--- a/Cmb2GridPluginLoad.php
+++ b/Cmb2GridPluginLoad.php
@@ -14,7 +14,8 @@ if ( ! class_exists( '\Cmb2Grid\Cmb2GridPlugin' ) ) {
 	class Cmb2GridPlugin extends DesignPatterns\Singleton {
 
 		const VERSION = '1.0';
-
+		private $url;
+		
 		protected function __construct() {
 			spl_autoload_register( array( $this, 'auto_load' ) );
 


### PR DESCRIPTION
Fixes the warning 'Deprecated: Creation of dynamic property Cmb2Grid\Cmb2GridPlugin::$url is deprecated'